### PR TITLE
[JIT] Static code reorder: allocate hottest methods into new code hea…

### DIFF
--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -437,6 +437,7 @@ void Compilation::install_code(int frame_size) {
     SharedRuntime::is_wide_vector(max_vector_size()),
     has_monitors(),
     has_scoped_access(),
+    false,
     _immediate_oops_patched
   );
 }

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -984,6 +984,7 @@ void ciEnv::register_method(ciMethod* target,
                             bool has_wide_vectors,
                             bool has_monitors,
                             bool has_scoped_access,
+                            bool alloc_in_non_profiled_hot_code_heap,
                             int immediate_oops_patched) {
   VM_ENTRY_MARK;
   nmethod* nm = nullptr;
@@ -1067,7 +1068,8 @@ void ciEnv::register_method(ciMethod* target,
                                debug_info(), dependencies(), code_buffer,
                                frame_words, oop_map_set,
                                handler_table, inc_table,
-                               compiler, CompLevel(task()->comp_level()));
+                               compiler, CompLevel(task()->comp_level()),
+                               alloc_in_non_profiled_hot_code_heap);
 
     // Free codeBlobs
     code_buffer->free_blob();

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -378,6 +378,7 @@ public:
                        bool                      has_wide_vectors,
                        bool                      has_monitors,
                        bool                      has_scoped_access,
+                       bool                      alloc_in_non_profiled_hot_code_heap,
                        int                       immediate_oops_patched);
 
   // Access to certain well known ciObjects.

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -37,6 +37,7 @@
 #include "oops/oop.inline.hpp"
 #include "prims/forte.hpp"
 #include "prims/jvmtiExport.hpp"
+#include "runtime/globals_extension.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/javaFrameAnchor.hpp"
@@ -478,7 +479,13 @@ void* VtableBlob::operator new(size_t s, unsigned size) throw() {
   // this context as we hold the CompiledICLocker. So we just don't handle code
   // cache exhaustion here; we leave that for a later allocation that does not
   // hold the CompiledICLocker.
-  return CodeCache::allocate(size, CodeBlobType::NonNMethod, false /* handle_alloc_failure */);
+  CodeBlobType code_blob_type;
+  if (AllocIVtableStubInNonProfiledHotCodeHeap && NonProfiledHotCodeHeapSize) {
+    code_blob_type = CodeBlobType::MethodHotNonProfiled;
+  } else {
+    code_blob_type = CodeBlobType::NonNMethod;
+  }
+  return CodeCache::allocate(size, code_blob_type, false /* handle_alloc_failure */);
 }
 
 VtableBlob::VtableBlob(const char* name, int size) :
@@ -509,6 +516,8 @@ VtableBlob* VtableBlob::create(const char* name, int buffer_size) {
       return nullptr;
     }
     blob = new (size) VtableBlob(name, size);
+    // Logging NonProfiledHotCodeHeap activities
+    CodeCache::trace_non_profiled_hot_code_heap_activities(tty, "Allocate", blob, size);
     CodeCache_lock->unlock();
   }
   // Track memory usage statistic after releasing CodeCache_lock

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -42,11 +42,12 @@ class OopMapSet;
 // CodeBlob Types
 // Used in the CodeCache to assign CodeBlobs to different CodeHeaps
 enum class CodeBlobType {
-  MethodNonProfiled   = 0,    // Execution level 1 and 4 (non-profiled) nmethods (including native nmethods)
-  MethodProfiled      = 1,    // Execution level 2 and 3 (profiled) nmethods
-  NonNMethod          = 2,    // Non-nmethods like Buffers, Adapters and Runtime Stubs
-  All                 = 3,    // All types (No code cache segmentation)
-  NumTypes            = 4     // Number of CodeBlobTypes
+  MethodNonProfiled    = 0,    // Execution level 1 and 4 (non-profiled) nmethods (including native nmethods)
+  MethodHotNonProfiled = 1,    // Hottest nmethods with NonProfiled
+  MethodProfiled       = 2,    // Execution level 2 and 3 (profiled) nmethods
+  NonNMethod           = 3,    // Non-nmethods like Buffers, Adapters and Runtime Stubs
+  All                  = 4,    // All types (No code cache segmentation)
+  NumTypes             = 5     // Number of CodeBlobTypes
 };
 
 // CodeBlob - superclass for all entries in the CodeCache.

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -201,6 +201,7 @@ void CodeCache::initialize_heaps() {
   CodeHeapInfo non_nmethod = {NonNMethodCodeHeapSize, FLAG_IS_CMDLINE(NonNMethodCodeHeapSize), true};
   CodeHeapInfo profiled = {ProfiledCodeHeapSize, FLAG_IS_CMDLINE(ProfiledCodeHeapSize), true};
   CodeHeapInfo non_profiled = {NonProfiledCodeHeapSize, FLAG_IS_CMDLINE(NonProfiledCodeHeapSize), true};
+  CodeHeapInfo non_profiled_hot = {NonProfiledHotCodeHeapSize, FLAG_IS_CMDLINE(NonProfiledHotCodeHeapSize), false};
 
   const bool cache_size_set   = FLAG_IS_CMDLINE(ReservedCodeCacheSize);
   const size_t ps             = page_size(false, 8);
@@ -229,23 +230,33 @@ void CodeCache::initialize_heaps() {
     non_nmethod.size += compiler_buffer_size;
   }
 
+  if (non_profiled_hot.set && non_profiled_hot.size > 0) {
+    non_profiled_hot.size = align_up(non_profiled_hot.size, min_size);
+    non_profiled_hot.enabled = true;
+  } else {
+    non_profiled_hot.size = 0;
+    non_profiled_hot.enabled = false;
+  }
+
+  size_t kept_size = non_nmethod.size + (non_profiled_hot.set ? non_profiled_hot.size : 0);
+
   if (!profiled.set && !non_profiled.set) {
-    non_profiled.size = profiled.size = (cache_size > non_nmethod.size + 2 * min_size) ?
-                                        (cache_size - non_nmethod.size) / 2 : min_size;
+    non_profiled.size = profiled.size = (cache_size > kept_size + 2 * min_size) ?
+                                        (cache_size - kept_size) / 2 : min_size;
   }
 
   if (profiled.set && !non_profiled.set) {
-    set_size_of_unset_code_heap(&non_profiled, cache_size, non_nmethod.size + profiled.size, min_size);
+    set_size_of_unset_code_heap(&non_profiled, cache_size, kept_size + profiled.size, min_size);
   }
 
   if (!profiled.set && non_profiled.set) {
-    set_size_of_unset_code_heap(&profiled, cache_size, non_nmethod.size + non_profiled.size, min_size);
+    set_size_of_unset_code_heap(&profiled, cache_size, kept_size + non_profiled.size, min_size);
   }
 
   // Compatibility.
   size_t non_nmethod_min_size = min_cache_size + compiler_buffer_size;
   if (!non_nmethod.set && profiled.set && non_profiled.set) {
-    set_size_of_unset_code_heap(&non_nmethod, cache_size, profiled.size + non_profiled.size, non_nmethod_min_size);
+    set_size_of_unset_code_heap(&non_nmethod, cache_size, profiled.size + non_profiled.size + non_profiled_hot.size, non_nmethod_min_size);
   }
 
   // Note: if large page support is enabled, min_size is at least the large
@@ -254,7 +265,7 @@ void CodeCache::initialize_heaps() {
   profiled.size = align_up(profiled.size, min_size);
   non_profiled.size = align_up(non_profiled.size, min_size);
 
-  size_t aligned_total = non_nmethod.size + profiled.size + non_profiled.size;
+  size_t aligned_total = non_nmethod.size + profiled.size + non_profiled.size + non_profiled_hot.size;
   if (!cache_size_set) {
     // If ReservedCodeCacheSize is explicitly set and exceeds CODE_CACHE_SIZE_LIMIT,
     // it is rejected by flag validation elsewhere. Here we only handle the case
@@ -262,15 +273,15 @@ void CodeCache::initialize_heaps() {
     // sizes (after alignment) exceed the platform limit.
     if (aligned_total > CODE_CACHE_SIZE_LIMIT) {
       err_msg message("ReservedCodeCacheSize (%zuK), Max (%zuK)."
-                      "Segments: NonNMethod (%zuK), NonProfiled (%zuK), Profiled (%zuK).",
+                      "Segments: NonNMethod (%zuK), NonProfiled (%zuK), Profiled (%zuK), NonProfiledHot (%zuK).",
                       aligned_total/K, CODE_CACHE_SIZE_LIMIT/K,
-                      non_nmethod.size/K, non_profiled.size/K, profiled.size/K);
+                      non_nmethod.size/K, non_profiled.size/K, profiled.size/K, non_profiled_hot.size/K);
       vm_exit_during_initialization("Code cache size exceeds platform limit", message);
     }
     if (aligned_total != cache_size) {
       log_info(codecache)("ReservedCodeCache size %zuK changed to total segments size NonNMethod "
-                          "%zuK NonProfiled %zuK Profiled %zuK = %zuK",
-                          cache_size/K, non_nmethod.size/K, non_profiled.size/K, profiled.size/K, aligned_total/K);
+                          "%zuK NonProfiled %zuK Profiled %zuK NonProfiledHot %zuK = %zuK",
+                          cache_size/K, non_nmethod.size/K, non_profiled.size/K, profiled.size/K, non_profiled_hot.size/K, aligned_total/K);
       // Adjust ReservedCodeCacheSize as necessary because it was not set explicitly
       cache_size = aligned_total;
     }
@@ -301,13 +312,13 @@ void CodeCache::initialize_heaps() {
           break;
         }
       }
-      aligned_total = non_nmethod.size + profiled.size + non_profiled.size;
+      aligned_total = non_nmethod.size + profiled.size + non_profiled.size + non_profiled_hot.size;
     }
   }
 
   log_debug(codecache)("Initializing code heaps ReservedCodeCache %zuK NonNMethod %zuK"
-                       " NonProfiled %zuK Profiled %zuK",
-                       cache_size/K, non_nmethod.size/K, non_profiled.size/K, profiled.size/K);
+                       " NonProfiled %zuK Profiled %zuK NonProfiledHot %zuK",
+                       cache_size/K, non_nmethod.size/K, non_profiled.size/K, profiled.size/K, non_profiled_hot.size/K);
 
   // Validation
   // Check minimal required sizes
@@ -318,6 +329,9 @@ void CodeCache::initialize_heaps() {
   if (non_profiled.enabled) { // non_profiled.enabled is always ON for segmented code heap, leave it checked for clarity
     check_min_size("non-profiled code heap", non_profiled.size, min_size);
   }
+  if (non_profiled_hot.enabled) {
+    check_min_size("non-profiled-hot code heap", non_profiled_hot.size, min_size);
+  }
 
   // ReservedCodeCacheSize was set explicitly, so report an error and abort if it doesn't match the segment sizes
   if (aligned_total != cache_size && cache_size_set) {
@@ -327,6 +341,9 @@ void CodeCache::initialize_heaps() {
     }
     if (non_profiled.enabled) {
       message.append(" + NonProfiledCodeHeapSize (%zuK)", non_profiled.size/K);
+    }
+    if (non_profiled_hot.enabled) {
+      message.append(" + NonProfiledHotCodeHeapSize (%zuK)", non_profiled_hot.size/K);
     }
     message.append(" = %zuK", aligned_total/K);
     message.append((aligned_total > cache_size) ? " is greater than " : " is less than ");
@@ -348,6 +365,7 @@ void CodeCache::initialize_heaps() {
   FLAG_SET_ERGO(NonNMethodCodeHeapSize, non_nmethod.size);
   FLAG_SET_ERGO(ProfiledCodeHeapSize, profiled.size);
   FLAG_SET_ERGO(NonProfiledCodeHeapSize, non_profiled.size);
+  FLAG_SET_ERGO(NonProfiledHotCodeHeapSize, non_profiled_hot.size);
   FLAG_SET_ERGO(ReservedCodeCacheSize, cache_size);
 
   ReservedSpace rs = reserve_heap_memory(cache_size, ps);
@@ -367,6 +385,13 @@ void CodeCache::initialize_heaps() {
   offset += non_nmethod.size;
   // Non-nmethods (stubs, adapters, ...)
   add_heap(non_method_space, "CodeHeap 'non-nmethods'", CodeBlobType::NonNMethod);
+
+  if (non_profiled_hot.enabled) {
+    ReservedSpace non_profiled_hot_space  = rs.partition(offset, non_profiled_hot.size);
+    offset += non_profiled_hot.size;
+    // non-profiled hot methods
+    add_heap(non_profiled_hot_space, "CodeHeap 'non-profiled hot nmethods'", CodeBlobType::MethodHotNonProfiled);
+  }
 
   if (non_profiled.enabled) {
     ReservedSpace non_profiled_space  = rs.partition(offset, non_profiled.size);
@@ -399,6 +424,12 @@ ReservedSpace CodeCache::reserve_heap_memory(size_t size, size_t rs_ps) {
 
 // Heaps available for allocation
 bool CodeCache::heap_available(CodeBlobType code_blob_type) {
+  if (code_blob_type == CodeBlobType::MethodHotNonProfiled) {
+    if (!NonProfiledHotCodeHeapSize) {
+      return false;
+    }
+  }
+
   if (!SegmentedCodeCache) {
     // No segmentation: use a single code heap
     return (code_blob_type == CodeBlobType::All);
@@ -411,7 +442,8 @@ bool CodeCache::heap_available(CodeBlobType code_blob_type) {
   } else {
     // No TieredCompilation: we only need the non-nmethod and non-profiled code heap
     return (code_blob_type == CodeBlobType::NonNMethod) ||
-           (code_blob_type == CodeBlobType::MethodNonProfiled);
+           (code_blob_type == CodeBlobType::MethodNonProfiled) ||
+           (code_blob_type == CodeBlobType::MethodHotNonProfiled);
   }
 }
 
@@ -422,6 +454,9 @@ const char* CodeCache::get_code_heap_flag_name(CodeBlobType code_blob_type) {
     break;
   case CodeBlobType::MethodNonProfiled:
     return "NonProfiledCodeHeapSize";
+    break;
+  case CodeBlobType::MethodHotNonProfiled:
+    return "NonProfiledHotCodeHeapSize";
     break;
   case CodeBlobType::MethodProfiled:
     return "ProfiledCodeHeapSize";
@@ -558,6 +593,9 @@ CodeBlob* CodeCache::allocate(uint size, CodeBlobType code_blob_type, bool handl
         // NonNMethod -> MethodNonProfiled -> MethodProfiled (-> MethodNonProfiled)
         CodeBlobType type = code_blob_type;
         switch (type) {
+        case CodeBlobType::MethodHotNonProfiled:
+          type = CodeBlobType::MethodNonProfiled;
+          break;
         case CodeBlobType::NonNMethod:
           type = CodeBlobType::MethodNonProfiled;
           break;
@@ -1149,6 +1187,12 @@ void CodeCache::initialize() {
   // default page size.
   CodeCacheExpansionSize = align_up(CodeCacheExpansionSize, os::vm_page_size());
 
+  if (NonProfiledHotCodeHeapSize) {
+    if (!SegmentedCodeCache) {
+      vm_exit_during_initialization("SegmentedCodeCache should be enabled when NonProfiledHotCodeHeapSize is specified");
+    }
+  }
+
   if (SegmentedCodeCache) {
     // Use multiple code heaps
     initialize_heaps();
@@ -1157,6 +1201,7 @@ void CodeCache::initialize() {
     FLAG_SET_ERGO(NonNMethodCodeHeapSize, (uintx)os::vm_page_size());
     FLAG_SET_ERGO(ProfiledCodeHeapSize, 0);
     FLAG_SET_ERGO(NonProfiledCodeHeapSize, 0);
+    FLAG_SET_ERGO(NonProfiledHotCodeHeapSize, 0);
 
     // If InitialCodeCacheSize is equal to ReservedCodeCacheSize, then it's more likely
     // users want to use the largest available page.
@@ -1828,6 +1873,61 @@ void CodeCache::print_summary(outputStream* st, bool detailed) {
                  CompileBroker::get_total_compiler_stopped_count(),
                  CompileBroker::get_total_compiler_restarted_count());
   }
+}
+
+void CodeCache::trace_non_profiled_hot_code_heap_activities(outputStream* st, const char* event, CodeBlob* cb, unsigned int size, bool detailed) {
+  if (!TraceNonProfiledHotCodeHeapActivities) {
+    return;
+  }
+
+  if (!CodeCache::heap_available(CodeBlobType::MethodHotNonProfiled)) {
+    return;
+  }
+
+  CodeHeap* heap = CodeCache::get_code_heap(cb);
+  assert(heap != nullptr, "code heap of code blob should not be null");
+
+  if (heap->code_blob_type() != CodeBlobType::MethodHotNonProfiled) {
+    return;
+  }
+
+  st->print_cr("----------------------------------------------------------");
+
+  if (strncmp(event, "Free", 4)) {
+    if (cb->is_nmethod()) {
+      nmethod* nm = (nmethod*)cb;
+      st->print_cr("%s a hottest method in NonProfiledHotCodeHeap: %s::%s%s, nmethod size is %d",
+                   event, nm->method()->klass_name()->as_utf8(), nm->method()->name()->as_utf8(),
+                   nm->method()->signature()->as_utf8(), size);
+    } else {
+      st->print_cr("%s a vtable chunk in NonProfiledHotCodeHeap: chunk size is %d", event, size);
+    }
+  } else {
+    st->print_cr("%s a hottest method in NonProfiledHotCodeHeap", event);
+  }
+
+  size_t total = heap->high_boundary() - heap->low_boundary();
+
+  st->print("%s:", heap->name());
+  st->print_cr(" size=" SIZE_FORMAT_X_0 "Kb used=" SIZE_FORMAT_X_0
+               "Kb max_used=" SIZE_FORMAT_X_0 "Kb free=" SIZE_FORMAT_X_0 "Kb",
+               total/K, (total - heap->unallocated_capacity())/K,
+               heap->max_allocated_capacity()/K, heap->unallocated_capacity()/K);
+
+  if (detailed) {
+    st->print_cr(" bounds [" INTPTR_FORMAT ", " INTPTR_FORMAT ", " INTPTR_FORMAT "]",
+                 p2i(heap->low_boundary()),
+                 p2i(heap->high()),
+                 p2i(heap->high_boundary()));
+
+    st->print_cr(" total_blobs=" UINT32_FORMAT " nmethods=" UINT32_FORMAT
+                 " full_count=" UINT32_FORMAT,
+                 heap->blob_count(),
+                 heap->nmethod_count(),
+                 heap->full_count());
+  }
+
+  return;
 }
 
 void CodeCache::print_codelist(outputStream* st) {

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -226,6 +226,7 @@ class CodeCache : AllStatic {
   static void verify();                          // verifies the code cache
   static void print_trace(const char* event, CodeBlob* cb, uint size = 0) PRODUCT_RETURN;
   static void print_summary(outputStream* st, bool detailed = true); // Prints a summary of the code cache usage
+  static void trace_non_profiled_hot_code_heap_activities(outputStream* st, const char* event, CodeBlob* cb, unsigned int size = 0, bool detailed = true);
   static void log_state(outputStream* st);
   LINUX_ONLY(static void write_perf_map(const char* filename, outputStream* st);) // Prints warnings and error messages to outputStream
   static const char* get_code_heap_name(CodeBlobType code_blob_type)  { return (heap_available(code_blob_type) ? get_code_heap(code_blob_type)->name() : "Unused"); }
@@ -264,10 +265,12 @@ class CodeCache : AllStatic {
   }
 
   static bool code_blob_type_accepts_nmethod(CodeBlobType type) {
+    // Accept nmethod: MethodHotNonProfiled should meet this requirement
     return type == CodeBlobType::All || type <= CodeBlobType::MethodProfiled;
   }
 
   static bool code_blob_type_accepts_allocable(CodeBlobType type) {
+    // Accept allocable: MethodHotNonProfiled should meet this requirement
     return type <= CodeBlobType::All;
   }
 
@@ -286,6 +289,18 @@ class CodeCache : AllStatic {
     }
     ShouldNotReachHere();
     return static_cast<CodeBlobType>(0);
+  }
+
+  // Returns the codeBlobType for the given method and compilation level
+  static CodeBlobType get_code_blob_type(const methodHandle& method, int comp_level, bool alloc_in_non_profiled_hot_code_heap) {
+    if (alloc_in_non_profiled_hot_code_heap && is_c2_compile(comp_level)) {
+      if (!method->is_native()) {
+        if (CodeCache::heap_available(CodeBlobType::MethodHotNonProfiled)) {
+          return CodeBlobType::MethodHotNonProfiled;
+        }
+      }
+    }
+    return get_code_blob_type(comp_level);
   }
 
   static void verify_clean_inline_caches();

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1095,6 +1095,7 @@ nmethod* nmethod::new_native_nmethod(const methodHandle& method,
   OopMapSet* oop_maps,
   int exception_handler) {
   code_buffer->finalize_oop_references(method);
+
   // create nmethod
   nmethod* nm = nullptr;
   int native_nmethod_size = CodeBlob::allocation_size(code_buffer, sizeof(nmethod));
@@ -1145,7 +1146,8 @@ nmethod* nmethod::new_nmethod(const methodHandle& method,
   ExceptionHandlerTable* handler_table,
   ImplicitExceptionTable* nul_chk_table,
   AbstractCompiler* compiler,
-  CompLevel comp_level
+  CompLevel comp_level,
+  bool alloc_in_non_profiled_hot_code_heap
 #if INCLUDE_JVMCI
   , char* speculations,
   int speculations_len,
@@ -1185,7 +1187,9 @@ nmethod* nmethod::new_nmethod(const methodHandle& method,
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
-    nm = new (nmethod_size, comp_level)
+    CodeBlobType code_blob_type = CodeCache::get_code_blob_type(method, comp_level, alloc_in_non_profiled_hot_code_heap);
+
+    nm = new (nmethod_size, code_blob_type)
     nmethod(method(), compiler->type(), nmethod_size, immutable_data_size, mutable_data_size,
             compile_id, entry_bci, immutable_data, offsets, orig_pc_offset,
             debug_info, dependencies, code_buffer, frame_size, oop_maps,
@@ -1221,6 +1225,9 @@ nmethod* nmethod::new_nmethod(const methodHandle& method,
         }
       }
       NOT_PRODUCT(if (nm != nullptr)  note_java_nmethod(nm));
+
+      // Logging NonProfiledHotCodeHeap activities
+      CodeCache::trace_non_profiled_hot_code_heap_activities(tty, "Allocate", nm, nmethod_size);
     }
   }
   // Do verification and logging outside CodeCache_lock.
@@ -1394,8 +1401,8 @@ nmethod::nmethod(
   }
 }
 
-void* nmethod::operator new(size_t size, int nmethod_size, int comp_level) throw () {
-  return CodeCache::allocate(nmethod_size, CodeCache::get_code_blob_type(comp_level));
+void* nmethod::operator new(size_t size, int nmethod_size, CodeBlobType code_blob_type) throw () {
+  return CodeCache::allocate(nmethod_size, code_blob_type);
 }
 
 void* nmethod::operator new(size_t size, int nmethod_size, bool allow_NonNMethod_space) throw () {

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -336,8 +336,7 @@ class nmethod : public CodeBlob {
           );
 
   // helper methods
-  void* operator new(size_t size, int nmethod_size, int comp_level) throw();
-
+  void* operator new(size_t size, int nmethod_size, CodeBlobType code_blob_type) throw();
   // For method handle intrinsics: Try MethodNonProfiled, MethodProfiled and NonNMethod.
   // Attention: Only allow NonNMethod space for special nmethods which don't need to be
   // findable by nmethod iterators! In particular, they must not contain oops!
@@ -561,7 +560,8 @@ public:
                               ExceptionHandlerTable* handler_table,
                               ImplicitExceptionTable* nul_chk_table,
                               AbstractCompiler* compiler,
-                              CompLevel comp_level
+                              CompLevel comp_level,
+                              bool alloc_in_non_profiled_hot_code_heap
 #if INCLUDE_JVMCI
                               , char* speculations = nullptr,
                               int speculations_len = 0,

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -86,6 +86,7 @@ NOT_PRODUCT(cflags(PrintIdeal,          bool, PrintIdeal, PrintIdeal)) \
 NOT_PRODUCT(cflags(PhasePrintLevel, intx, PrintPhaseLevel, PhasePrintLevel)) \
 NOT_PRODUCT(cflags(IGVPrintLevel,   intx, PrintIdealGraphLevel, IGVPrintLevel)) \
     cflags(IncrementalInlineForceCleanup, bool, IncrementalInlineForceCleanup, IncrementalInlineForceCleanup) \
+    cflags(AllocInNonProfiledHotCodeHeap, bool, false, AllocInNonProfiledHotCodeHeap) \
     cflags(MaxNodeLimit,            intx, MaxNodeLimit, MaxNodeLimit)
 #define compilerdirectives_c2_string_flags(cflags) \
 NOT_PRODUCT(cflags(TraceAutoVectorization, ccstrlist, "", TraceAutoVectorization)) \

--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -77,6 +77,7 @@ class methodHandle;
   option(CompileThresholdScaling, "CompileThresholdScaling", Double) \
   option(ControlIntrinsic,  "ControlIntrinsic",  Ccstrlist) \
   option(DisableIntrinsic,  "DisableIntrinsic",  Ccstrlist) \
+  option(AllocInNonProfiledHotCodeHeap, "AllocInNonProfiledHotCodeHeap", Bool) \
   option(BlockLayoutByFrequency, "BlockLayoutByFrequency", Bool) \
   option(TraceOptoPipelining, "TraceOptoPipelining", Bool) \
   option(TraceOptoOutput, "TraceOptoOutput", Bool) \

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -309,7 +309,7 @@
   product(ccstr, CompileCommandFile, nullptr,                               \
           "Read compiler commands from this file [.hotspot_compiler]")      \
                                                                             \
-  product(ccstr, CompilerDirectivesFile, nullptr, DIAGNOSTIC,               \
+  product(ccstr, CompilerDirectivesFile, nullptr,                           \
           "Read compiler directives from this file")                        \
                                                                             \
   product(ccstrlist, CompileCommand, "",                                    \

--- a/src/hotspot/share/gc/shared/classUnloadingContext.cpp
+++ b/src/hotspot/share/gc/shared/classUnloadingContext.cpp
@@ -161,11 +161,15 @@ void ClassUnloadingContext::free_nmethods() {
     for (nmethod* nm : *nmethod_set) {
       MutexLocker ml(CodeCache_lock, Mutex::_no_safepoint_check_flag);
       CodeCache::free(nm);
+      // Logging NonProfiledHotCodeHeap activities
+      CodeCache::trace_non_profiled_hot_code_heap_activities(tty, "Free", nm);
     }
   } else {
     MutexLocker ml(CodeCache_lock, Mutex::_no_safepoint_check_flag);
     for (nmethod* nm : *nmethod_set) {
       CodeCache::free(nm);
+      // Logging NonProfiledHotCodeHeap activities
+      CodeCache::trace_non_profiled_hot_code_heap_activities(tty, "Free", nm);
     }
   }
 

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -2161,6 +2161,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
                                  frame_words, oop_map_set,
                                  handler_table, implicit_exception_table,
                                  compiler, comp_level,
+                                 false, // No jvmci support for allocation inside NonProfiledHotCodeHeap
                                  speculations, speculations_len, data);
 
 
@@ -2170,7 +2171,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
         {
           MutexUnlocker ml(Compile_lock);
           MutexUnlocker locker(MethodCompileQueue_lock);
-          CompileBroker::handle_full_code_cache(CodeCache::get_code_blob_type(comp_level));
+          CompileBroker::handle_full_code_cache(CodeCache::get_code_blob_type(method, comp_level, false));
         }
         result = JVMCI::cache_full;
       } else {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -652,6 +652,7 @@ Compile::Compile(ciEnv* ci_env, ciMethod* target, int osr_bci,
 #endif
       _has_method_handle_invokes(false),
       _clinit_barrier_on_entry(false),
+      _alloc_in_non_profiled_hot_code_heap(false),
       _stress_seed(0),
       _comp_arena(mtCompiler, Arena::Tag::tag_comp),
       _barrier_set_state(BarrierSet::barrier_set()->barrier_set_c2()->create_barrier_state(comp_arena())),
@@ -724,6 +725,9 @@ Compile::Compile(ciEnv* ci_env, ciMethod* target, int osr_bci,
 
   if (directive->ReplayInlineOption) {
     _replay_inline_data = ciReplay::load_inline_data(method(), entry_bci(), ci_env->comp_level());
+  }
+  if (NonProfiledHotCodeHeapSize) {
+    set_alloc_in_non_profiled_hot_code_heap(directive->AllocInNonProfiledHotCodeHeapOption);
   }
   set_print_inlining(directive->PrintInliningOption || PrintOptoInlining);
   set_print_intrinsics(directive->PrintIntrinsicsOption);
@@ -934,6 +938,7 @@ Compile::Compile(ciEnv* ci_env,
 #endif
       _has_method_handle_invokes(false),
       _clinit_barrier_on_entry(false),
+      _alloc_in_non_profiled_hot_code_heap(false),
       _stress_seed(0),
       _comp_arena(mtCompiler, Arena::Tag::tag_comp),
       _barrier_set_state(BarrierSet::barrier_set()->barrier_set_c2()->create_barrier_state(comp_arena())),

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -360,6 +360,7 @@ class Compile : public Phase {
   bool                  _has_scoped_access;     // For shared scope closure
   bool                  _clinit_barrier_on_entry; // True if clinit barrier is needed on nmethod entry
   int                   _loop_opts_cnt;         // loop opts round
+  bool                  _alloc_in_non_profiled_hot_code_heap;
   uint                  _stress_seed;           // Seed for stress testing
 
   // Compilation environment.
@@ -637,6 +638,8 @@ public:
   void          set_max_node_limit(uint n)       { _max_node_limit = n; }
   bool              clinit_barrier_on_entry()       { return _clinit_barrier_on_entry; }
   void          set_clinit_barrier_on_entry(bool z) { _clinit_barrier_on_entry = z; }
+  bool              alloc_in_non_profiled_hot_code_heap() const { return _alloc_in_non_profiled_hot_code_heap; }
+  void          set_alloc_in_non_profiled_hot_code_heap(bool z) { _alloc_in_non_profiled_hot_code_heap = z; }
   bool              has_monitors() const         { return _has_monitors; }
   void          set_has_monitors(bool v)         { _has_monitors = v; }
   bool              has_scoped_access() const    { return _has_scoped_access; }

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -3453,6 +3453,7 @@ void PhaseOutput::install_code(ciMethod*         target,
                                      has_unsafe_access,
                                      SharedRuntime::is_wide_vector(C->max_vector_size()),
                                      C->has_monitors(),
+                                     C->alloc_in_non_profiled_hot_code_heap(),
                                      C->has_scoped_access(),
                                      0);
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2018,6 +2018,15 @@ const int ObjectAlignmentInBytes = 8;
           "Minimal number of elements in a sorted collection to prefer"     \
           "binary search over simple linear search." )                      \
                                                                             \
+  product(bool, TraceNonProfiledHotCodeHeapActivities, false, DIAGNOSTIC,   \
+          "Trace activities of NonProfiledHotCodeHeap")                     \
+                                                                            \
+  product(uintx, NonProfiledHotCodeHeapSize, 0,                             \
+          "Size of hot code heap with non-profiled methods (in bytes)")     \
+          range(0, max_uintx)                                               \
+                                                                            \
+  product(bool, AllocIVtableStubInNonProfiledHotCodeHeap, false,            \
+          "Allocate itable/vtable in NonProfiledHotCodeHeap")               \
 
 // end of RUNTIME_FLAGS
 

--- a/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
@@ -48,6 +48,7 @@ public class CheckSegmentedCodeCache {
     private static final String NON_METHOD = "CodeHeap 'non-nmethods'";
     private static final String PROFILED = "CodeHeap 'profiled nmethods'";
     private static final String NON_PROFILED = "CodeHeap 'non-profiled nmethods'";
+    private static final String NON_PROFILED_HOT = "CodeHeap 'non-profiled hot nmethods'";
 
     private static void verifySegmentedCodeCache(ProcessBuilder pb, boolean enabled) throws Exception {
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
@@ -123,12 +124,22 @@ public class CheckSegmentedCodeCache {
                                                               "-XX:+PrintCodeCache",
                                                               "-version");
         verifySegmentedCodeCache(pb, false);
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:ReservedCodeCacheSize=239m",
+                                                              "-XX:NonProfiledHotCodeHeapSize=1m",
+                                                              "-XX:+PrintCodeCache",
+                                                              "-version");
+        failsWith(pb, "SegmentedCodeCache should be enabled when NonProfiledHotCodeHeapSize is specified");
 
         // Disabled without TieredCompilation
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:-TieredCompilation",
                                                               "-XX:+PrintCodeCache",
                                                               "-version");
         verifySegmentedCodeCache(pb, false);
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:-TieredCompilation",
+                                                              "-XX:NonProfiledHotCodeHeapSize=1m",
+                                                              "-XX:+PrintCodeCache",
+                                                              "-version");
+        failsWith(pb, "SegmentedCodeCache should be enabled when NonProfiledHotCodeHeapSize is specified");
 
         // Enabled with TieredCompilation and ReservedCodeCacheSize >= 240MB
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+TieredCompilation",
@@ -141,11 +152,24 @@ public class CheckSegmentedCodeCache {
                                                               "-XX:+PrintCodeCache",
                                                               "-version");
         verifySegmentedCodeCache(pb, true);
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+TieredCompilation",
+                                                              "-XX:ReservedCodeCacheSize=400m",
+                                                              "-XX:NonProfiledHotCodeHeapSize=1m",
+                                                              "-XX:+PrintCodeCache",
+                                                              "-version");
+        verifySegmentedCodeCache(pb, true);
 
         // Always enabled if SegmentedCodeCache is set
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+SegmentedCodeCache",
                                                               "-XX:-TieredCompilation",
                                                               "-XX:ReservedCodeCacheSize=239m",
+                                                              "-XX:+PrintCodeCache",
+                                                              "-version");
+        verifySegmentedCodeCache(pb, true);
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+SegmentedCodeCache",
+                                                              "-XX:-TieredCompilation",
+                                                              "-XX:ReservedCodeCacheSize=239m",
+                                                              "-XX:NonProfiledHotCodeHeapSize=1m",
                                                               "-XX:+PrintCodeCache",
                                                               "-version");
         verifySegmentedCodeCache(pb, true);
@@ -156,7 +180,7 @@ public class CheckSegmentedCodeCache {
                                                               "-Xint",
                                                               "-XX:+PrintCodeCache",
                                                               "-version");
-        verifyCodeHeapNotExists(pb, PROFILED, NON_PROFILED);
+        verifyCodeHeapNotExists(pb, PROFILED, NON_PROFILED, NON_PROFILED_HOT);
 
         // If we stop compilation at CompLevel_none or CompLevel_simple we
         // don't need a profiled code heap.
@@ -164,12 +188,12 @@ public class CheckSegmentedCodeCache {
                                                               "-XX:TieredStopAtLevel=0",
                                                               "-XX:+PrintCodeCache",
                                                               "-version");
-        verifyCodeHeapNotExists(pb, PROFILED);
+        verifyCodeHeapNotExists(pb, PROFILED, NON_PROFILED_HOT);
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+SegmentedCodeCache",
                                                               "-XX:TieredStopAtLevel=1",
                                                               "-XX:+PrintCodeCache",
                                                               "-version");
-        verifyCodeHeapNotExists(pb, PROFILED);
+        verifyCodeHeapNotExists(pb, PROFILED, NON_PROFILED_HOT);
 
         // Fails with too small non-nmethod code heap size
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:NonNMethodCodeHeapSize=100K",

--- a/test/hotspot/jtreg/compiler/codecache/OverflowCodeCacheTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/OverflowCodeCacheTest.java
@@ -42,6 +42,20 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:-SegmentedCodeCache -Xmixed
  *                   compiler.codecache.OverflowCodeCacheTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:+TieredCompilation
+ *                   -XX:+SegmentedCodeCache -Xmixed
+ *                   compiler.codecache.OverflowCodeCacheTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:+TieredCompilation
+ *                   -XX:+SegmentedCodeCache -Xmixed
+ *                   -XX:NonProfiledHotCodeHeapSize=1m
+ *                   compiler.codecache.OverflowCodeCacheTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:-TieredCompilation
+ *                   -XX:+SegmentedCodeCache -Xmixed
+ *                   -XX:NonProfiledHotCodeHeapSize=1m
+ *                   compiler.codecache.OverflowCodeCacheTest
  */
 
 package compiler.codecache;

--- a/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/GenericCodeHeapSizeRunner.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/GenericCodeHeapSizeRunner.java
@@ -69,5 +69,13 @@ public class GenericCodeHeapSizeRunner implements CodeCacheCLITestCase.Runner {
                         BlobType.MethodProfiled.sizeOptionName,
                         expectedValues.profiled),
                 testCaseDescription.getTestOptions(options));
+
+        CommandLineOptionTest.verifyOptionValueForSameVM(
+                BlobType.MethodHotNonProfiled.sizeOptionName,
+                Long.toString(expectedValues.hotNonProfiled),
+                String.format("%s should have value %d.",
+                        BlobType.MethodHotNonProfiled.sizeOptionName,
+                        expectedValues.hotNonProfiled),
+                testCaseDescription.getTestOptions(options));
     }
 }

--- a/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/JVMStartupRunner.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/JVMStartupRunner.java
@@ -63,11 +63,11 @@ public class JVMStartupRunner implements CodeCacheCLITestCase.Runner {
             throws Throwable {
         verifyHeapSizesSum(options.reserved,
                 scaleCodeHeapSize(options.profiled), options.nonProfiled,
-                options.nonNmethods);
+                options.nonNmethods, options.hotNonProfiled);
         verifyHeapSizesSum(options.reserved, options.profiled,
-                scaleCodeHeapSize(options.nonProfiled), options.nonNmethods);
+                scaleCodeHeapSize(options.nonProfiled), options.nonNmethods, options.hotNonProfiled);
         verifyHeapSizesSum(options.reserved, options.profiled,
-                options.nonProfiled, scaleCodeHeapSize(options.nonNmethods));
+                options.nonProfiled, scaleCodeHeapSize(options.nonNmethods), options.hotNonProfiled);
     }
 
     /**
@@ -80,19 +80,21 @@ public class JVMStartupRunner implements CodeCacheCLITestCase.Runner {
         long profiled = options.profiled;
         long nonProfiled = options.nonProfiled;
         long nonNMethods = options.nonNmethods;
+        long hotNonProfiled = options.hotNonProfiled;
 
-        while (options.reserved == profiled + nonProfiled + nonNMethods) {
+        while (options.reserved == profiled + nonProfiled + nonNMethods + hotNonProfiled) {
             profiled = scaleCodeHeapSize(profiled);
             nonProfiled = scaleCodeHeapSize(nonProfiled);
             nonNMethods = scaleCodeHeapSize(nonNMethods);
+            hotNonProfiled = scaleCodeHeapSize(hotNonProfiled);
         }
 
         verifyHeapSizesSum(options.reserved, profiled, nonProfiled,
-                nonNMethods);
+                nonNMethods, hotNonProfiled);
     }
 
     private static void verifyHeapSizesSum(long reserved, long profiled,
-            long nonProfiled, long nonNmethods) throws Throwable {
+            long nonProfiled, long nonNmethods, long hotNonProfiled) throws Throwable {
         // JVM startup expected to fail when
         // sum(all code heap sizes) != reserved CC size
         CommandLineOptionTest.verifySameJVMStartup(
@@ -111,7 +113,9 @@ public class JVMStartupRunner implements CodeCacheCLITestCase.Runner {
                 CommandLineOptionTest.prepareNumericFlag(
                         BlobType.MethodNonProfiled.sizeOptionName, nonProfiled),
                 CommandLineOptionTest.prepareNumericFlag(
-                        BlobType.NonNMethod.sizeOptionName, nonNmethods));
+                        BlobType.NonNMethod.sizeOptionName, nonNmethods),
+                CommandLineOptionTest.prepareNumericFlag(
+                        BlobType.MethodHotNonProfiled.sizeOptionName, hotNonProfiled));
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
@@ -68,10 +68,19 @@ public class TestCodeHeapSizeOptions extends CodeCacheCLITestBase {
                         .CommonDescriptions.NON_TIERED.description,
                         GENERIC_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
+                        .CommonDescriptions.NON_TIERED_FOR_HOT_NON_PROFILED.description,
+                        GENERIC_RUNNER),
+                new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.TIERED_LEVEL_1.description,
                         GENERIC_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
+                        .CommonDescriptions.TIERED_LEVEL_1_FOR_HOT_NON_PROFILED.description,
+                        GENERIC_RUNNER),
+                new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.TIERED_LEVEL_4.description,
+                        GENERIC_RUNNER),
+                new CodeCacheCLITestCase(CodeCacheCLITestCase
+                        .CommonDescriptions.TIERED_LEVEL_4_FOR_HOT_NON_PROFILED.description,
                         GENERIC_RUNNER),
                 JVM_STARTUP,
                 CODE_CACHE_FREE_SPACE);

--- a/test/hotspot/jtreg/compiler/codecache/cli/common/CodeCacheCLITestBase.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/common/CodeCacheCLITestBase.java
@@ -40,7 +40,18 @@ public class CodeCacheCLITestBase {
                     CodeCacheOptions.mB(100)),
             new CodeCacheOptions(CodeCacheOptions.mB(60)),
             new CodeCacheOptions(CodeCacheOptions.mB(200)),
-            new CodeCacheOptions(CodeCacheOptions.mB(300))
+            new CodeCacheOptions(CodeCacheOptions.mB(300)),
+
+            // Support for NonProfiledHotCodeHeap
+            new CodeCacheOptions(CodeCacheOptions.mB(70),
+                    CodeCacheOptions.mB(20), CodeCacheOptions.mB(20),
+                    CodeCacheOptions.mB(20), CodeCacheOptions.mB(10)),
+            new CodeCacheOptions(CodeCacheOptions.mB(210),
+                    CodeCacheOptions.mB(75), CodeCacheOptions.mB(75),
+                    CodeCacheOptions.mB(50), CodeCacheOptions.mB(10)),
+            new CodeCacheOptions(CodeCacheOptions.mB(400),
+                    CodeCacheOptions.mB(100), CodeCacheOptions.mB(100),
+                    CodeCacheOptions.mB(100), CodeCacheOptions.mB(100))
     };
 
     private final CodeCacheCLITestCase[] testCases;

--- a/test/hotspot/jtreg/compiler/codecache/cli/printcodecache/TestPrintCodeCacheOption.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/printcodecache/TestPrintCodeCacheOption.java
@@ -64,13 +64,22 @@ public class TestPrintCodeCacheOption extends CodeCacheCLITestBase {
                         .CommonDescriptions.NON_TIERED.description,
                         DEFAULT_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
+                        .CommonDescriptions.NON_TIERED_FOR_HOT_NON_PROFILED.description,
+                        DEFAULT_RUNNER),
+                new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.TIERED_LEVEL_0.description,
                         DEFAULT_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.TIERED_LEVEL_1.description,
                         DEFAULT_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
+                        .CommonDescriptions.TIERED_LEVEL_1_FOR_HOT_NON_PROFILED.description,
+                        DEFAULT_RUNNER),
+                new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.TIERED_LEVEL_4.description,
+                        DEFAULT_RUNNER),
+                new CodeCacheCLITestCase(CodeCacheCLITestCase
+                        .CommonDescriptions.TIERED_LEVEL_4_FOR_HOT_NON_PROFILED.description,
                         DEFAULT_RUNNER),
                 DISABLED_PRINT_CODE_CACHE);
     }

--- a/test/hotspot/jtreg/compiler/codecache/jmx/BeanTypeTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/BeanTypeTest.java
@@ -36,6 +36,11 @@
  *     compiler.codecache.jmx.BeanTypeTest
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.BeanTypeTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.BeanTypeTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/CodeCacheUtils.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/CodeCacheUtils.java
@@ -95,7 +95,7 @@ public final class CodeCacheUtils {
      * @return boolean value, true if respective code heap is predictable
      */
     public static boolean isCodeHeapPredictable(BlobType btype) {
-        return btype == BlobType.MethodProfiled;
+        return btype == BlobType.MethodProfiled || btype == BlobType.MethodHotNonProfiled;
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/codecache/jmx/CodeHeapBeanPresenceTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/CodeHeapBeanPresenceTest.java
@@ -38,6 +38,11 @@
  *     -XX:+WhiteBoxAPI
  *     -XX:+SegmentedCodeCache
  *     compiler.codecache.jmx.CodeHeapBeanPresenceTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.CodeHeapBeanPresenceTest
  */
 
 package compiler.codecache.jmx;

--- a/test/hotspot/jtreg/compiler/codecache/jmx/GetUsageTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/GetUsageTest.java
@@ -38,6 +38,12 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
  *     -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.GetUsageTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
+ *     -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.GetUsageTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/InitialAndMaxUsageTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/InitialAndMaxUsageTest.java
@@ -38,6 +38,12 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:-UseCodeCacheFlushing
  *     -XX:-MethodFlushing -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:CompileCommand=compileonly,null::* -XX:-UseLargePages
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.InitialAndMaxUsageTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:-UseCodeCacheFlushing
+ *     -XX:-MethodFlushing -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:CompileCommand=compileonly,null::* -XX:-UseLargePages
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.InitialAndMaxUsageTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/ManagerNamesTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/ManagerNamesTest.java
@@ -36,6 +36,11 @@
  *     compiler.codecache.jmx.ManagerNamesTest
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.ManagerNamesTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.ManagerNamesTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/MemoryPoolsPresenceTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/MemoryPoolsPresenceTest.java
@@ -36,6 +36,11 @@
  *     compiler.codecache.jmx.MemoryPoolsPresenceTest
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.MemoryPoolsPresenceTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.MemoryPoolsPresenceTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/PeakUsageTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/PeakUsageTest.java
@@ -35,6 +35,11 @@
  *     compiler.codecache.jmx.PeakUsageTest
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.PeakUsageTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.PeakUsageTest
  * @summary testing of getPeakUsage() and resetPeakUsage for

--- a/test/hotspot/jtreg/compiler/codecache/jmx/PoolsIndependenceTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/PoolsIndependenceTest.java
@@ -36,6 +36,11 @@
  *     compiler.codecache.jmx.PoolsIndependenceTest
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.PoolsIndependenceTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.PoolsIndependenceTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/ThresholdNotificationsTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/ThresholdNotificationsTest.java
@@ -36,6 +36,11 @@
  *     compiler.codecache.jmx.ThresholdNotificationsTest
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xbootclasspath/a:. -XX:-UseCodeCacheFlushing
  *     -XX:+WhiteBoxAPI -XX:-MethodFlushing -XX:CompileCommand=compileonly,null::*
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.ThresholdNotificationsTest
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xbootclasspath/a:. -XX:-UseCodeCacheFlushing
+ *     -XX:+WhiteBoxAPI -XX:-MethodFlushing -XX:CompileCommand=compileonly,null::*
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.ThresholdNotificationsTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdExceededSeveralTimesTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdExceededSeveralTimesTest.java
@@ -39,6 +39,12 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *      -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
  *      -XX:CompileCommand=compileonly,null::* -Djdk.test.lib.iterations=10
+ *      -XX:+SegmentedCodeCache
+ *      -XX:NonProfiledHotCodeHeapSize=50m
+ *      compiler.codecache.jmx.UsageThresholdExceededTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
+ *      -XX:CompileCommand=compileonly,null::* -Djdk.test.lib.iterations=10
  *      -XX:-SegmentedCodeCache
  *      compiler.codecache.jmx.UsageThresholdExceededTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdExceededTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdExceededTest.java
@@ -39,6 +39,12 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing  -XX:-MethodFlushing
  *     -XX:CompileCommand=compileonly,null::*
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.UsageThresholdExceededTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing  -XX:-MethodFlushing
+ *     -XX:CompileCommand=compileonly,null::*
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.UsageThresholdExceededTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdIncreasedTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdIncreasedTest.java
@@ -40,6 +40,12 @@
  *     -XX:CompileCommand=compileonly,null::*
  *     -XX:+SegmentedCodeCache
  *     compiler.codecache.jmx.UsageThresholdIncreasedTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing  -XX:-MethodFlushing
+ *     -XX:CompileCommand=compileonly,null::*
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.UsageThresholdIncreasedTest
  */
 
 package compiler.codecache.jmx;

--- a/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdNotExceededTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdNotExceededTest.java
@@ -39,6 +39,12 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
  *     -XX:CompileCommand=compileonly,null::*
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.UsageThresholdNotExceededTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
+ *     -XX:CompileCommand=compileonly,null::*
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.UsageThresholdNotExceededTest
  */

--- a/test/hotspot/jtreg/compiler/whitebox/AllocationCodeBlobTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/AllocationCodeBlobTest.java
@@ -38,6 +38,11 @@
  *                   -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
  *                   -XX:+SegmentedCodeCache
  *                   compiler.whitebox.AllocationCodeBlobTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
+ *                   -XX:+SegmentedCodeCache
+ *                   -XX:NonProfiledHotCodeHeapSize=50m
+ *                   compiler.whitebox.AllocationCodeBlobTest
  */
 
 package compiler.whitebox;

--- a/test/hotspot/jtreg/compiler/whitebox/GetCodeHeapEntriesTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/GetCodeHeapEntriesTest.java
@@ -36,6 +36,10 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:+SegmentedCodeCache
  *                   compiler.whitebox.GetCodeHeapEntriesTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:+SegmentedCodeCache
+ *                   -XX:NonProfiledHotCodeHeapSize=50m
+ *                   compiler.whitebox.GetCodeHeapEntriesTest
  */
 
 package compiler.whitebox;

--- a/test/hotspot/jtreg/compiler/whitebox/GetNMethodTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/GetNMethodTest.java
@@ -34,7 +34,8 @@
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -Xmixed -XX:+UnlockDiagnosticVMOptions
- *                   -XX:+WhiteBoxAPI
+ *                   -XX:NonProfiledHotCodeHeapSize=0
+ *                   -XX:+WhiteBoxAPI -XX:-UseCounterDecay
  *                   -XX:CompileCommand=compileonly,compiler.whitebox.SimpleTestCaseHelper::*
  *                   compiler.whitebox.GetNMethodTest
  */

--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -30,7 +30,8 @@
  * @author  Mandy Chung
  *
  * @modules jdk.management
- * @run main MemoryTest 2 3
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=0 MemoryTest 2 3 5
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=10m MemoryTest 2 3 6
  */
 
 /*
@@ -42,7 +43,8 @@
  * @author  Mandy Chung
  *
  * @modules jdk.management
- * @run main/othervm -XX:+UseZGC MemoryTest 4 2
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=0 -XX:+UseZGC -XX:+ZGenerational MemoryTest 4 2 5
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=10m -XX:+UseZGC -XX:+ZGenerational MemoryTest 4 2 6
  */
 
 /*
@@ -54,7 +56,8 @@
  * @author  Mandy Chung
  *
  * @modules jdk.management
- * @run main MemoryTest 2 1
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=0 MemoryTest 2 1 5
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=10m MemoryTest 2 1 6
  */
 
 /*
@@ -78,7 +81,8 @@
  * @author  Mandy Chung
  *
  * @modules jdk.management
- * @run main/othervm -XX:+UseG1GC MemoryTest 3 3
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=0 -XX:+UseG1GC MemoryTest 3 3 5
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=10m -XX:+UseG1GC MemoryTest 3 3 6
  */
 
 /*
@@ -126,11 +130,13 @@ public class MemoryTest {
         expectedNumMgrs = expectedNumGCMgrs + 2;
 
         int expectedNumPools = Integer.valueOf(args[1]);
+        int expectedMaxNumPoolsOfNonHeap = Integer.valueOf(args[2]);
+
         expectedMinNumPools[HEAP] = expectedNumPools;
         expectedMaxNumPools[HEAP] = expectedNumPools;
 
         expectedMinNumPools[NONHEAP] = 2;
-        expectedMaxNumPools[NONHEAP] = 5;
+        expectedMaxNumPools[NONHEAP] = expectedMaxNumPoolsOfNonHeap;
 
         checkMemoryPools();
         checkMemoryManagers();

--- a/test/lib/jdk/test/whitebox/code/BlobType.java
+++ b/test/lib/jdk/test/whitebox/code/BlobType.java
@@ -38,8 +38,17 @@ public enum BlobType {
                     || type == BlobType.MethodProfiled;
         }
     },
+    // Execution level 4 (non-profiled hot) nmethods (without native nmethods)
+    MethodHotNonProfiled(1, "CodeHeap 'non-profiled hot nmethods'", "NonProfiledHotCodeHeapSize") {
+        @Override
+        public boolean allowTypeWhenOverflow(BlobType type) {
+            return super.allowTypeWhenOverflow(type)
+                    || type == BlobType.MethodNonProfiled
+                    || type == BlobType.MethodProfiled;
+        }
+    },
     // Execution level 2 and 3 (profiled) nmethods
-    MethodProfiled(1, "CodeHeap 'profiled nmethods'", "ProfiledCodeHeapSize") {
+    MethodProfiled(2, "CodeHeap 'profiled nmethods'", "ProfiledCodeHeapSize") {
         @Override
         public boolean allowTypeWhenOverflow(BlobType type) {
             return super.allowTypeWhenOverflow(type)
@@ -47,7 +56,7 @@ public enum BlobType {
         }
     },
     // Non-nmethods like Buffers, Adapters and Runtime Stubs
-    NonNMethod(2, "CodeHeap 'non-nmethods'", "NonNMethodCodeHeapSize") {
+    NonNMethod(3, "CodeHeap 'non-nmethods'", "NonNMethodCodeHeapSize") {
         @Override
         public boolean allowTypeWhenOverflow(BlobType type) {
             return super.allowTypeWhenOverflow(type)
@@ -56,7 +65,7 @@ public enum BlobType {
         }
     },
     // All types (No code cache segmentation)
-    All(3, "CodeCache", "ReservedCodeCacheSize");
+    All(4, "CodeCache", "ReservedCodeCacheSize");
 
     public final int id;
     public final String sizeOptionName;
@@ -98,6 +107,9 @@ public enum BlobType {
                 || whiteBox.getIntxVMFlag("TieredStopAtLevel") <= 1) {
             // there is no MethodProfiled in non tiered world or pure C1
             result.remove(MethodProfiled);
+        }
+        if (whiteBox.getUintxVMFlag("NonProfiledHotCodeHeapSize") == 0) {
+            result.remove(MethodHotNonProfiled);
         }
         return result;
     }


### PR DESCRIPTION
[JIT] Static code reorder: allocate hottest methods into new code heap "NonProfiledHotCodeHeap"

Summary:
1. Introduce a new code heap: divide a separated region "NonProfiledHotCodeHeap" from NonProfiled segment.
2. The size of NonProfiledHotCodeHeap is configurable.
3. Introduce a new CodeBlobType "MethodHotNonProfiled" corresponds to all methods inside the new region.
4. JIT could allocate nmethods into this separated region.
5. JIT could allocate itable/vtable stub in NonProfiledHotCodeHeap.
6. When "NonProfiledHotCodeHeap" is not enough to hold "hottest" methods anymore, allocate it into the original "NonProfiled" segment.
7. Code cache sweep support of "NonProfiledHotCodeHeap".
8. Introduce option "AllocIVtableStubInNonProfiledHotCodeHeap" to reorder itable/vtable stub.
9. Compiler Directive definition.
10. Method filter: Only matched C2 compiled "hottest" functions are placed into "NonProfiledHotCodeHeap".
11. Support "PrintCodeCache" ... options.
12. Log support for easy debug.
13. Add tests for the new code heap.
14. Turn "CompilerDirectivesFile" into a product option.

Testing: jtreg

Reviewers: lingjun-cg, D-D-H

Issue: https://github.com/dragonwell-project/dragonwell25/issues/26