### PR TITLE
[Misc] Remove UseCounterDecay from GetNMethodTest.java

### DIFF
--- a/test/hotspot/jtreg/compiler/whitebox/GetNMethodTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/GetNMethodTest.java
@@ -35,7 +35,7 @@
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -Xmixed -XX:+UnlockDiagnosticVMOptions
  *                   -XX:NonProfiledHotCodeHeapSize=0
- *                   -XX:+WhiteBoxAPI -XX:-UseCounterDecay
+ *                   -XX:+WhiteBoxAPI
  *                   -XX:CompileCommand=compileonly,compiler.whitebox.SimpleTestCaseHelper::*
  *                   compiler.whitebox.GetNMethodTest
  */


### PR DESCRIPTION
Summary: obosolete UseCounterDecay option is added in static code reorder patch

Testing: GetNMethodTest.java

Reviewers: lingjun-cg, D-D-H

Issue: https://project.aone.alibaba-inc.com/coco/projects/355606/workitems/83752543